### PR TITLE
feat: Implement file system storage for code

### DIFF
--- a/lib/models/problem.dart
+++ b/lib/models/problem.dart
@@ -1,6 +1,7 @@
 class Problem {
   final String title;
   final String statement;
+  final String contestName; // Added contestName
   final String constraints;
   final String inputFormat;
   final String outputFormat;
@@ -10,6 +11,7 @@ class Problem {
   Problem({
     required this.title,
     required this.statement,
+    required this.contestName, // Added contestName
     required this.constraints,
     required this.inputFormat,
     required this.outputFormat,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -414,7 +414,7 @@ packages:
     source: hosted
     version: "1.9.1"
   path_provider:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: path_provider
       sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -414,7 +414,7 @@ packages:
     source: hosted
     version: "1.9.1"
   path_provider:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path_provider
       sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,6 +29,7 @@ dependencies:
   
   # 設定の保存に必要
   shared_preferences: ^2.5.3
+  path_provider: ^2.0.0
   provider: ^6.1.5
   flutter_html: ^3.0.0
   webview_flutter: ^4.13.0


### PR DESCRIPTION
エディタでのコードの保存と読み込みに関して、shared_preferences をファイルシステムストレージに置き換えました。ソースコードは、<アプリのドキュメントディレクトリ>/<コンテスト名>/<問題名>/main.<言語拡張子> のパスに保存されるようになります。
変更点：
 * ファイルシステムディレクトリへのアクセス用に path_provider の依存関係を追加しました。
 * Problem モデルに contestName を含めるように更新しました。
 * コンテストの AtCoder ページからコンテスト名を取得するように AtCoderService を強化しました。
 * EditorScreen に言語とファイル拡張子のマッピングを実装しました。
 * EditorScreen の _saveCode、_loadSavedCode、_restoreCode メソッドを dart:io を使用したファイル操作に書き直しました。
 * コンテスト名や問題名に含まれる特殊文字を処理するために、ファイル名のサニタイズを追加しました。
 * ディレクトリが再帰的に作成されるようにしました。
 * テンプレートの保存と読み込みを防ぐために default_problem のケースを処理しました。
 * 正しいファイルパスを確保するために、コンテスト名を含む問題詳細が取得された後にコードが読み込まれるようになりました。
