### PR TITLE
feat: Implement code history feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ app.*.map.json
 
 # FVM Version Cache
 .fvm/
+flutter-sdk/

--- a/lib/models/code_history.dart
+++ b/lib/models/code_history.dart
@@ -1,0 +1,27 @@
+class CodeHistory {
+  final String id;
+  final String content;
+  final DateTime timestamp;
+
+  CodeHistory({
+    required this.id,
+    required this.content,
+    required this.timestamp,
+  });
+
+  factory CodeHistory.fromJson(Map<String, dynamic> json) {
+    return CodeHistory(
+      id: json['id'],
+      content: json['content'],
+      timestamp: DateTime.parse(json['timestamp']),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'content': content,
+      'timestamp': timestamp.toIso8601String(),
+    };
+  }
+}

--- a/lib/screens/code_history_screen.dart
+++ b/lib/screens/code_history_screen.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import '../models/code_history.dart';
+import '../services/code_history_service.dart';
+
+class CodeHistoryScreen extends StatefulWidget {
+  final String problemId;
+
+  const CodeHistoryScreen({super.key, required this.problemId});
+
+  @override
+  _CodeHistoryScreenState createState() => _CodeHistoryScreenState();
+}
+
+class _CodeHistoryScreenState extends State<CodeHistoryScreen> {
+  final CodeHistoryService _codeHistoryService = CodeHistoryService();
+  late Future<List<CodeHistory>> _historyFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _historyFuture = _codeHistoryService.getHistory(widget.problemId);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Code History'),
+      ),
+      body: FutureBuilder<List<CodeHistory>>(
+        future: _historyFuture,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          } else if (snapshot.hasError) {
+            return Center(child: Text('Error: ${snapshot.error}'));
+          } else if (!snapshot.hasData || snapshot.data!.isEmpty) {
+            return const Center(child: Text('No history found.'));
+          } else {
+            final historyList = snapshot.data!;
+            return ListView.builder(
+              itemCount: historyList.length,
+              itemBuilder: (context, index) {
+                final history = historyList[index];
+                return ListTile(
+                  title: Text(DateFormat.yMMMd().add_jms().format(history.timestamp)),
+                  subtitle: Text(
+                    history.content,
+                    maxLines: 2,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  onTap: () => _showHistoryDetailDialog(history),
+                );
+              },
+            );
+          }
+        },
+      ),
+    );
+  }
+
+  void _showHistoryDetailDialog(CodeHistory history) {
+    showDialog(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text(DateFormat.yMMMd().add_jms().format(history.timestamp)),
+        content: SingleChildScrollView(
+          child: SelectableText(history.content),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('Close'),
+          ),
+          TextButton(
+            onPressed: () {
+              Navigator.of(context).pop(); // Close the dialog
+              Navigator.of(context).pop(history.content); // Pop the screen and return the code
+            },
+            child: const Text('Restore'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/editor_screen.dart
+++ b/lib/screens/editor_screen.dart
@@ -772,7 +772,9 @@ public class Main {
     // ★★★ デバッグログ追加 ★★★
 
 
-    return Column(
+    return Padding(
+      padding: const EdgeInsets.only(bottom: kBottomNavigationBarHeight + 8),
+      child: Column(
       children: [
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 4.0, vertical: 2.0),
@@ -1034,7 +1036,7 @@ public class Main {
             flex: 2,
             child: Row(
               children: [
-                // 左: 標準入力
+                // 左: 標準入力（デザイン統一）
                 Expanded(
                   child: Card(
                     elevation: 1,
@@ -1047,16 +1049,25 @@ public class Main {
                           Text('標準入力 (stdin)', style: Theme.of(context).textTheme.titleSmall),
                           const SizedBox(height: 8),
                           Expanded(
-                            child: TextField(
-                              controller: _stdinController,
-                              expands: true,
-                              maxLines: null,
-                              decoration: const InputDecoration(
-                                hintText: 'プログラムへの入力をここに入力します',
-                                border: OutlineInputBorder(),
-                                isDense: true,
+                            child: Container(
+                              width: double.infinity,
+                              decoration: BoxDecoration(
+                                color: Theme.of(context).colorScheme.surfaceContainerHighest.withOpacity(0.3),
+                                borderRadius: BorderRadius.circular(4),
+                                border: Border.all(color: Theme.of(context).dividerColor.withOpacity(0.5)),
                               ),
-                              style: GoogleFonts.sourceCodePro(fontSize: 13),
+                              padding: const EdgeInsets.all(8),
+                              child: TextField(
+                                controller: _stdinController,
+                                expands: true,
+                                maxLines: null,
+                                decoration: const InputDecoration(
+                                  hintText: 'プログラムへの入力をここに入力します',
+                                  border: InputBorder.none,
+                                  isDense: true,
+                                ),
+                                style: GoogleFonts.sourceCodePro(fontSize: 13),
+                              ),
                             ),
                           ),
                         ],
@@ -1064,67 +1075,67 @@ public class Main {
                     ),
                   ),
                 ),
-                // 右: 実行結果 (stdout/stderr)
+                // 右: 実行結果 (stdout/stderr)（デザイン統一）
                 Expanded(
                   child: Card(
                     elevation: 1,
                     margin: const EdgeInsets.symmetric(vertical: 4.0, horizontal: 2.0),
                     child: Padding(
                       padding: const EdgeInsets.all(8.0),
-                      child: SingleChildScrollView(
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            // --- Standard Output Display ---
-                            if (_output.isNotEmpty)
-                              Text(
-                                '実行結果 (stdout):',
-                                style: Theme.of(context).textTheme.titleSmall,
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          // stdout セクション
+                          Text('標準出力 (stdout)', style: Theme.of(context).textTheme.titleSmall),
+                          const SizedBox(height: 8),
+                          Expanded(
+                            child: Container(
+                              width: double.infinity,
+                              decoration: BoxDecoration(
+                                color: Theme.of(context).colorScheme.surfaceContainerHighest.withOpacity(0.3),
+                                borderRadius: BorderRadius.circular(4),
+                                border: Border.all(color: Theme.of(context).dividerColor.withOpacity(0.5)),
                               ),
-                            if (_output.isNotEmpty)
-                              SelectableText(
-                                _output,
-                                style: GoogleFonts.sourceCodePro(fontSize: 13),
-                              ),
-
-                            // --- Error Output Display ---
-                            if (_error.isNotEmpty)
-                              Padding(
-                                padding: EdgeInsets.only(top: _output.isNotEmpty ? 8.0 : 0),
-                                child: Row(
-                                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                                  children: [
-                                    Text(
-                                      'エラー出力 (stderr):',
-                                      style: Theme.of(context).textTheme.titleSmall?.copyWith(color: Colors.red),
-                                    ),
-                                    IconButton(
-                                      icon: const Icon(Icons.copy, size: 18),
-                                      tooltip: 'エラーをコピー',
-                                      onPressed: () {
-                                        Clipboard.setData(ClipboardData(text: _error));
-                                        ScaffoldMessenger.of(context).showSnackBar(
-                                          const SnackBar(content: Text('エラー出力をコピーしました')),
-                                        );
-                                      },
-                                    ),
-                                  ],
+                              padding: const EdgeInsets.all(8),
+                              child: Scrollbar(
+                                thumbVisibility: true,
+                                child: SingleChildScrollView(
+                                  child: SelectableText(
+                                    _output.isEmpty && _error.isEmpty && !_isRunning
+                                      ? '実行ボタンを押すと、ここに結果が表示されます。'
+                                      : (_output.isEmpty ? '(空)' : _output),
+                                    style: GoogleFonts.sourceCodePro(fontSize: 13),
+                                  ),
                                 ),
                               ),
-                            if (_error.isNotEmpty)
-                              SelectableText(
-                                _error,
-                                style: GoogleFonts.sourceCodePro(fontSize: 13, color: Colors.red),
-                              ),
+                            ),
+                          ),
 
-                            // --- Placeholder Text ---
-                            if (_output.isEmpty && _error.isEmpty && !_isRunning)
-                               const Text(
-                                 '実行ボタンを押すと、ここに結果が表示されます。',
-                                 style: TextStyle(color: Colors.grey),
-                               ),
+                          // stderr セクション
+                          if (_error.isNotEmpty) ...[
+                            const SizedBox(height: 12),
+                            Text('エラー出力 (stderr)', style: Theme.of(context).textTheme.titleSmall?.copyWith(color: Colors.red)),
+                            const SizedBox(height: 8),
+                            Container(
+                              width: double.infinity,
+                              decoration: BoxDecoration(
+                                color: Theme.of(context).colorScheme.surfaceContainerHighest.withOpacity(0.3),
+                                borderRadius: BorderRadius.circular(4),
+                                border: Border.all(color: Theme.of(context).dividerColor.withOpacity(0.5)),
+                              ),
+                              padding: const EdgeInsets.all(8),
+                              child: Scrollbar(
+                                thumbVisibility: true,
+                                child: SingleChildScrollView(
+                                  child: SelectableText(
+                                    _error,
+                                    style: GoogleFonts.sourceCodePro(fontSize: 13, color: Colors.red),
+                                  ),
+                                ),
+                              ),
+                            ),
                           ],
-                        ),
+                        ],
                       ),
                     ),
                   ),
@@ -1134,8 +1145,7 @@ public class Main {
           ),
         ],
       ],
+    )
     );
   }
-
-  // ... other methods (_runCode, _runTests, etc.) ...
 }

--- a/lib/screens/editor_screen.dart
+++ b/lib/screens/editor_screen.dart
@@ -783,6 +783,23 @@ public class Main {
       padding: EdgeInsets.only(bottom: systemBottomInset + navBarHeight + 8),
       child: Column(
       children: [
+        if (_currentProblem != null)
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 4.0),
+            child: Row(
+              children: [
+                const Icon(Icons.assignment, size: 18),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    '${_currentProblem!.contestName} · ${_currentProblem!.title}',
+                    style: Theme.of(context).textTheme.titleMedium,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+              ],
+            ),
+          ),
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 4.0, vertical: 2.0),
           child: Row(

--- a/lib/screens/editor_screen.dart
+++ b/lib/screens/editor_screen.dart
@@ -24,6 +24,9 @@ import 'submit_screen.dart'; // 提出画面を表示するWebViewスクリー�
 import '../services/code_history_service.dart';
 import 'code_history_screen.dart';
 
+// 3点メニュー用のアクション列挙体（トップレベルに定義）
+enum _ToolbarAction { runTests, save, history, restore, reset, share }
+
 class EditorScreen extends StatefulWidget {
   final String problemId; // 問題IDを追加
 
@@ -752,7 +755,6 @@ public class Main {
     }
   }
 
-
   @override
   Widget build(BuildContext context) {
     final bool isLoadingProblem = _isLoadingCode || (widget.problemId != 'default_problem' && _currentProblem == null);
@@ -795,56 +797,27 @@ public class Main {
                   ),
                 ],
               ),
-              // ツールバーボタン (実行ボタンは削除)
-              Row(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  // ... other buttons ...
-                  IconButton( // テスト実行ボタン
-                    icon: _isTesting
-                        ? const SizedBox(width: 20, height: 20, child: CircularProgressIndicator(strokeWidth: 2))
-                        : const Icon(Icons.checklist_rtl),
-                    tooltip: 'テスト実行 (サンプルケース)',
-                    onPressed: isButtonDisabled
-                        ? null
-                        : () { // onPressedがnullでない場合の処理
-                            print("★★★ Test Button Pressed! ★★★"); // このログが出るか確認
-                            _runTests();
-                          },
-                  ),
-                  IconButton( // 提出ボタン
-                    icon: const Icon(Icons.cloud_upload),
-                    tooltip: '提出',
-                    onPressed: () {
-                      final parts = widget.problemId.split('_');
-                      final contestId = parts.isNotEmpty ? parts[0] : widget.problemId;
-                      final url = 'https://atcoder.jp/contests/$contestId/submit?taskScreenName=${widget.problemId}';
-                      Navigator.push(
-                        context,
-                        MaterialPageRoute(
-                          builder: (_) => SubmitScreen(
-                            url: url,
-                            initialCode: _codeController.text,
-                            initialLanguage: _selectedLanguage,
-                          ),
-                        ),
-                      );
-                    },
-                  ),
-                  IconButton( // 保存ボタン
-                    icon: const Icon(Icons.save_alt),
-                    tooltip: '保存',
-                    onPressed: _saveCode,
-                  ),
-                  IconButton(
-                    icon: const Icon(Icons.history),
-                    tooltip: 'コード履歴',
-                    onPressed: () async {
+              // 3点メニュー（オーバーフローメニュー）
+              PopupMenuButton<_ToolbarAction>(
+                icon: const Icon(Icons.more_vert),
+                tooltip: 'その他',
+                onSelected: (action) async {
+                  switch (action) {
+                    case _ToolbarAction.runTests:
+                      if (!isButtonDisabled) {
+                        print("★★★ Test Menu Selected! ★★★");
+                        _runTests();
+                      }
+                      break;
+                    case _ToolbarAction.save:
+                      _saveCode();
+                      break;
+                    case _ToolbarAction.history:
                       if (widget.problemId.isEmpty || widget.problemId == 'default_problem') {
                         ScaffoldMessenger.of(context).showSnackBar(
                           const SnackBar(content: Text('No problem selected.')),
                         );
-                        return;
+                        break;
                       }
                       final restoredCode = await Navigator.push(
                         context,
@@ -860,47 +833,79 @@ public class Main {
                           const SnackBar(content: Text('Code restored from history.')),
                         );
                       }
-                    },
-                  ),
-                  IconButton( // 復元ボタン
-                    icon: const Icon(Icons.settings_backup_restore),
-                    tooltip: '復元',
-                    onPressed: _restoreCode,
-                  ),
-                  IconButton( // リセットボタン
-                    icon: const Icon(Icons.replay),
-                    tooltip: 'リセット',
-                    onPressed: () {
+                      break;
+                    case _ToolbarAction.restore:
+                      _restoreCode();
+                      break;
+                    case _ToolbarAction.reset:
                       _codeController.text = _getTemplateForLanguage(_selectedLanguage);
                       _stdinController.clear();
                       setState(() {
-                         _output = '';
-                         _error = '';
+                        _output = '';
+                        _error = '';
                       });
-                    },
-                  ),
-                  IconButton( // 共有ボタン
-                    icon: const Icon(Icons.share),
-                    tooltip: 'コード共有',
-                    onPressed: () {
+                      break;
+                    case _ToolbarAction.share:
                       final code = _codeController.text;
                       if (code.isEmpty) {
                         ScaffoldMessenger.of(context).showSnackBar(
                           const SnackBar(content: Text('共有するコードがありません')),
                         );
-                        return;
+                        break;
                       }
                       String textToShare = code;
                       if (_currentProblem != null) {
-                        // textToShare に問題のタイトルと言語を追加
                         textToShare = '${_currentProblem!.title} ($_selectedLanguage)\n\n$code';
                       }
-                      // SharePlus.instance.share を使用するように変更
-                      // 共有するテキストを ShareParams の text パラメータに渡す
                       SharePlus.instance.share(
                         ShareParams(text: textToShare),
                       );
-                    },
+                      break;
+                  }
+                },
+                itemBuilder: (context) => [
+                  PopupMenuItem<_ToolbarAction>(
+                    value: _ToolbarAction.runTests,
+                    enabled: !isButtonDisabled,
+                    child: Row(
+                      children: [
+                        const Icon(Icons.checklist_rtl),
+                        const SizedBox(width: 8),
+                        Text(_isTesting ? 'テスト実行中…' : 'テスト実行 (サンプルケース)'),
+                      ],
+                    ),
+                  ),
+                  const PopupMenuDivider(),
+                  PopupMenuItem<_ToolbarAction>(
+                    value: _ToolbarAction.save,
+                    child: Row(
+                      children: const [Icon(Icons.save_alt), SizedBox(width: 8), Text('保存')],
+                    ),
+                  ),
+                  PopupMenuItem<_ToolbarAction>(
+                    value: _ToolbarAction.history,
+                    child: Row(
+                      children: const [Icon(Icons.history), SizedBox(width: 8), Text('コード履歴')],
+                    ),
+                  ),
+                  PopupMenuItem<_ToolbarAction>(
+                    value: _ToolbarAction.restore,
+                    child: Row(
+                      children: const [Icon(Icons.settings_backup_restore), SizedBox(width: 8), Text('復元')],
+                    ),
+                  ),
+                  PopupMenuItem<_ToolbarAction>(
+                    value: _ToolbarAction.reset,
+                    child: Row(
+                      children: const [Icon(Icons.replay), SizedBox(width: 8), Text('リセット')],
+                    ),
+                  ),
+                  const PopupMenuDivider(),
+                  PopupMenuItem<_ToolbarAction>(
+                    value: _ToolbarAction.share,
+                    child: Row(
+                      children: const [Icon(Icons.share), SizedBox(width: 8), Text('コード共有')],
+                    ),
                   ),
                 ],
               ),
@@ -965,24 +970,55 @@ public class Main {
                   ),
                 ),
                 const SizedBox(width: 8), // フィールドとボタンの間隔
-                // 実行ボタン (ElevatedButtonに変更)
-                ElevatedButton.icon(
-                  icon: _isRunning
-                      ? SizedBox( // 実行中はインジケーター
-                          width: 18,
-                          height: 18,
-                          child: CircularProgressIndicator(
-                            strokeWidth: 2,
-                            color: Theme.of(context).colorScheme.onPrimary, // ボタン色に合わせた色
+                // 右側に 提出/実行 の縦並びボタン
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.end,
+                  children: [
+                    // 提出ボタン
+                    ElevatedButton.icon(
+                      icon: const Icon(Icons.cloud_upload),
+                      label: const Text('提出'),
+                      onPressed: () {
+                        final parts = widget.problemId.split('_');
+                        final contestId = parts.isNotEmpty ? parts[0] : widget.problemId;
+                        final url = 'https://atcoder.jp/contests/$contestId/submit?taskScreenName=${widget.problemId}';
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (_) => SubmitScreen(
+                              url: url,
+                              initialCode: _codeController.text,
+                              initialLanguage: _selectedLanguage,
+                            ),
                           ),
-                        )
-                      : const Icon(Icons.play_arrow),
-                  label: const Text('実行'),
-                  onPressed: _isRunning ? null : _runCode, // 実行中は無効
-                  style: ElevatedButton.styleFrom(
-                    padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12), // 少し大きめに
-                    textStyle: const TextStyle(fontSize: 14),
-                  ),
+                        );
+                      },
+                      style: ElevatedButton.styleFrom(
+                        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                        textStyle: const TextStyle(fontSize: 14),
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    // 実行ボタン (ElevatedButtonに変更)
+                    ElevatedButton.icon(
+                      icon: _isRunning
+                          ? SizedBox( // 実行中はインジケーター
+                              width: 18,
+                              height: 18,
+                              child: CircularProgressIndicator(
+                                strokeWidth: 2,
+                                color: Theme.of(context).colorScheme.onPrimary, // ボタン色に合わせた色
+                              ),
+                            )
+                          : const Icon(Icons.play_arrow),
+                      label: const Text('実行'),
+                      onPressed: _isRunning ? null : _runCode, // 実行中は無効
+                      style: ElevatedButton.styleFrom(
+                        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12), // 少し大きめに
+                        textStyle: const TextStyle(fontSize: 14),
+                      ),
+                    ),
+                  ],
                 ),
               ],
             ),

--- a/lib/screens/editor_screen.dart
+++ b/lib/screens/editor_screen.dart
@@ -772,8 +772,15 @@ public class Main {
     // ★★★ デバッグログ追加 ★★★
 
 
+    // Material 3 の NavigationBar はデフォルトで高さが 80px 程度あるため、
+    // 従来の kBottomNavigationBarHeight(56) だと下部が隠れることがある。
+    // 端末のボトムインセットも考慮して余白を動的に算出する。
+    final double systemBottomInset = MediaQuery.of(context).padding.bottom;
+    final bool isM3 = Theme.of(context).useMaterial3;
+    final double navBarHeight = isM3 ? 80.0 : kBottomNavigationBarHeight; // カスタムバーの場合は適宜調整
+
     return Padding(
-      padding: const EdgeInsets.only(bottom: kBottomNavigationBarHeight + 8),
+      padding: EdgeInsets.only(bottom: systemBottomInset + navBarHeight + 8),
       child: Column(
       children: [
         Padding(

--- a/lib/screens/editor_screen.dart
+++ b/lib/screens/editor_screen.dart
@@ -965,73 +965,82 @@ public class Main {
             padding: const EdgeInsets.symmetric(horizontal: 4.0, vertical: 4.0),
             child: Row(
               children: [
-                // 実行
-                ElevatedButton.icon(
-                  icon: _isRunning
-                      ? SizedBox(
-                          width: 18,
-                          height: 18,
-                          child: CircularProgressIndicator(
-                            strokeWidth: 2,
-                            color: Theme.of(context).colorScheme.onPrimary,
-                          ),
-                        )
-                      : const Icon(Icons.play_arrow),
-                  label: const Text('実行'),
-                  onPressed: _isRunning ? null : _runCode,
-                  style: ElevatedButton.styleFrom(
-                    padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
-                    textStyle: const TextStyle(fontSize: 14),
+                // 実行（横幅1/3）
+                Expanded(
+                  child: ElevatedButton.icon(
+                    icon: _isRunning
+                        ? SizedBox(
+                            width: 18,
+                            height: 18,
+                            child: CircularProgressIndicator(
+                              strokeWidth: 2,
+                              color: Theme.of(context).colorScheme.onPrimary,
+                            ),
+                          )
+                        : const Icon(Icons.play_arrow),
+                    label: const Text('実行'),
+                    onPressed: _isRunning ? null : _runCode,
+                    style: ElevatedButton.styleFrom(
+                      minimumSize: const Size.fromHeight(44),
+                      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+                      textStyle: const TextStyle(fontSize: 14),
+                    ),
                   ),
                 ),
                 const SizedBox(width: 8),
-                // サンプル
-                ElevatedButton.icon(
-                  icon: _isTesting
-                      ? SizedBox(
-                          width: 18,
-                          height: 18,
-                          child: CircularProgressIndicator(
-                            strokeWidth: 2,
-                            color: Theme.of(context).colorScheme.onPrimary,
-                          ),
-                        )
-                      : const Icon(Icons.checklist_rtl),
-                  label: Text(_isTesting ? 'サンプルテスト中…' : 'サンプル'),
-                  onPressed: isButtonDisabled
-                      ? null
-                      : () {
-                          print('★★★ Test Button Pressed! ★★★');
-                          _runTests();
-                        },
-                  style: ElevatedButton.styleFrom(
-                    padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
-                    textStyle: const TextStyle(fontSize: 14),
+                // サンプル（横幅1/3）
+                Expanded(
+                  child: ElevatedButton.icon(
+                    icon: _isTesting
+                        ? SizedBox(
+                            width: 18,
+                            height: 18,
+                            child: CircularProgressIndicator(
+                              strokeWidth: 2,
+                              color: Theme.of(context).colorScheme.onPrimary,
+                            ),
+                          )
+                        : const Icon(Icons.checklist_rtl),
+                    label: Text(_isTesting ? 'サンプルテスト中…' : 'サンプル'),
+                    onPressed: isButtonDisabled
+                        ? null
+                        : () {
+                            print('★★★ Test Button Pressed! ★★★');
+                            _runTests();
+                          },
+                    style: ElevatedButton.styleFrom(
+                      minimumSize: const Size.fromHeight(44),
+                      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+                      textStyle: const TextStyle(fontSize: 14),
+                    ),
                   ),
                 ),
                 const SizedBox(width: 8),
-                // 提出
-                ElevatedButton.icon(
-                  icon: const Icon(Icons.cloud_upload),
-                  label: const Text('提出'),
-                  onPressed: () {
-                    final parts = widget.problemId.split('_');
-                    final contestId = parts.isNotEmpty ? parts[0] : widget.problemId;
-                    final url = 'https://atcoder.jp/contests/$contestId/submit?taskScreenName=${widget.problemId}';
-                    Navigator.push(
-                      context,
-                      MaterialPageRoute(
-                        builder: (_) => SubmitScreen(
-                          url: url,
-                          initialCode: _codeController.text,
-                          initialLanguage: _selectedLanguage,
+                // 提出（横幅1/3）
+                Expanded(
+                  child: ElevatedButton.icon(
+                    icon: const Icon(Icons.cloud_upload),
+                    label: const Text('提出'),
+                    onPressed: () {
+                      final parts = widget.problemId.split('_');
+                      final contestId = parts.isNotEmpty ? parts[0] : widget.problemId;
+                      final url = 'https://atcoder.jp/contests/$contestId/submit?taskScreenName=${widget.problemId}';
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (_) => SubmitScreen(
+                            url: url,
+                            initialCode: _codeController.text,
+                            initialLanguage: _selectedLanguage,
+                          ),
                         ),
-                      ),
-                    );
-                  },
-                  style: ElevatedButton.styleFrom(
-                    padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
-                    textStyle: const TextStyle(fontSize: 14),
+                      );
+                    },
+                    style: ElevatedButton.styleFrom(
+                      minimumSize: const Size.fromHeight(44),
+                      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+                      textStyle: const TextStyle(fontSize: 14),
+                    ),
                   ),
                 ),
               ],

--- a/lib/screens/editor_screen.dart
+++ b/lib/screens/editor_screen.dart
@@ -777,7 +777,7 @@ public class Main {
     // 端末のボトムインセットも考慮して余白を動的に算出する。
     final double systemBottomInset = MediaQuery.of(context).padding.bottom;
     final bool isM3 = Theme.of(context).useMaterial3;
-    final double navBarHeight = isM3 ? 80.0 : kBottomNavigationBarHeight; // カスタムバーの場合は適宜調整
+    final double navBarHeight = isM3 ? 0.0 : kBottomNavigationBarHeight; // カスタムバーの場合は適宜調整
 
     return Padding(
       padding: EdgeInsets.only(bottom: systemBottomInset + navBarHeight + 8),

--- a/lib/services/code_history_service.dart
+++ b/lib/services/code_history_service.dart
@@ -1,0 +1,76 @@
+import 'dart:io';
+
+import 'package:path_provider/path_provider.dart';
+import '../models/code_history.dart';
+
+class CodeHistoryService {
+  Future<String> _getHistoryDirectoryPath(String problemId) async {
+    final directory = await getApplicationDocumentsDirectory();
+    return '${directory.path}/code_history/$problemId';
+  }
+
+  Future<void> saveHistory(String problemId, String code) async {
+    if (code.trim().isEmpty) {
+      return;
+    }
+
+    final historyDirectoryPath = await _getHistoryDirectoryPath(problemId);
+    final historyDirectory = Directory(historyDirectoryPath);
+    if (!await historyDirectory.exists()) {
+      await historyDirectory.create(recursive: true);
+    }
+
+    final timestamp = DateTime.now();
+    final id = timestamp.millisecondsSinceEpoch.toString();
+    final historyFile = File('$historyDirectoryPath/$id.txt');
+
+    // To avoid saving too many identical versions, check the latest history
+    final history = await getHistory(problemId);
+    if (history.isNotEmpty) {
+      final latestHistory = history.first;
+      if (latestHistory.content.trim() == code.trim()) {
+        return; // Don't save if the content is the same as the latest
+      }
+    }
+
+    await historyFile.writeAsString(code);
+  }
+
+  Future<List<CodeHistory>> getHistory(String problemId) async {
+    final historyDirectoryPath = await _getHistoryDirectoryPath(problemId);
+    final historyDirectory = Directory(historyDirectoryPath);
+
+    if (!await historyDirectory.exists()) {
+      return [];
+    }
+
+    final files = await historyDirectory.list().toList();
+    final historyList = <CodeHistory>[];
+
+    for (var fileEntity in files) {
+      if (fileEntity is File) {
+        final id = fileEntity.uri.pathSegments.last.split('.').first;
+        final timestamp = DateTime.fromMillisecondsSinceEpoch(int.parse(id));
+        final content = await fileEntity.readAsString();
+
+        historyList.add(CodeHistory(
+          id: id,
+          content: content,
+          timestamp: timestamp,
+        ));
+      }
+    }
+
+    historyList.sort((a, b) => b.timestamp.compareTo(a.timestamp));
+    return historyList;
+  }
+
+  Future<void> clearHistory(String problemId) async {
+    final historyDirectoryPath = await _getHistoryDirectoryPath(problemId);
+    final historyDirectory = Directory(historyDirectoryPath);
+
+    if (await historyDirectory.exists()) {
+      await historyDirectory.delete(recursive: true);
+    }
+  }
+}

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,30 +1,29 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility in the flutter_test package. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
-
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-
+import 'package:provider/provider.dart';
 import 'package:shojin_app/main.dart';
+import 'package:shojin_app/providers/theme_provider.dart';
+import 'package:shojin_app/providers/template_provider.dart';
+import 'package:shojin_app/providers/contest_provider.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
+  testWidgets('App starts without crashing', (WidgetTester tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+    await tester.pumpWidget(
+      MultiProvider(
+        providers: [
+          ChangeNotifierProvider(create: (_) => ThemeProvider()),
+          ChangeNotifierProvider(create: (_) => TemplateProvider()),
+          ChangeNotifierProvider(create: (_) => ContestProvider()),
+        ],
+        child: const MyApp(),
+      ),
+    );
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
+    // Wait for all frames to settle.
+    await tester.pumpAndSettle(const Duration(seconds: 5)); // Increased duration to allow for async operations
 
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    // Verify that our app shows the main screen.
+    expect(find.byType(MainScreen), findsOneWidget);
   });
 }


### PR DESCRIPTION
このパッチは、エディターで書かれたコードの履歴を保存・復元する機能を導入します。

主な機能
- コードの履歴は、2秒間入力を止めると自動的に保存されます。
- 保存された履歴のリストをタイムスタンプ順に表示する画面が追加されました。
- 履歴エントリを選択すると、コード全体を表示し、エディタに復元できます。
- 履歴はデバイスにローカルに保存され、各問題は独自の履歴を持ちます。

テストに関する注意：
既存のテストスイートには失敗するテストがいくつかあります（`widget_test.dart` と `update_service_test.dart`）。これらの失敗は、テストのセットアップにおける既存の問題、特にテスト環境におけるネットワークリクエストに関連しているようです。必要なプロバイダを提供することで`widget_test.dart`を修正する努力をしましたが、テストにおけるアプリ起動時の非同期操作に関する根本的な問題は残っています。これらのテストの失敗は、新しいコード履歴機能とは無関係です。
*** Translated with www.DeepL.com/Translator (free version) ***

