### PR TITLE
docs: expand v2.0.0 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,72 +2,65 @@
 
 ## [2.0.0] - 2026-07-16
 
-- ci: remove Gemini and license snapshot workflows
-- 🐛 fix: reliably cancel Android contest reminders
-- 🔧 chore(deps): bump the pub-minor-patch group across 1 directory with 3 updates
-- 🔧 chore: remove unused code blocks from the repository Cleaned up the codebase by eliminating redundant code sections to improve maintainability and readability.
-- ♻️  refactor: rebuild editor around code workspace
-- 🐛 fix: update Flutter version to 3.44.6
-- 🐛 fix: preserve TeX in input format blocks
-- 📝 docs: AGENTS.mdにコミットの頻度に関するガイドラインを追加
-- 🐛 fix: polish problem statement rendering
-- Keep problem input identification keys unique
-- 🔧 chore(deps): bump fastlane from 2.236.1 to 2.237.0
-- 🔧 chore(deps): bump xcodeproj from 1.27.0 to 1.28.1
-- Harden browser metadata and submit navigation checks
-- 🐛 fix: improve text rendering and input handling in various screens - Adjusted text alignment and padding in the editor screen for better usability. - Enhanced the problem detail screen to preserve semantic emphasis and list markers. - Updated the TexWidget to handle inline Markdown formatting more effectively. - Added tests to ensure proper rendering of formatted content.
-- 🐛 fix: refine problem content layout and parsing
-- 🐛 fix: stabilize editor input and widget reordering
-- 🐛 fix: apply AtCoder accent color family
-- ✅ test: assert Material You icon separation
-- ✅ test: cover Material You icon contrast
-- ci: pin Flutter to mise version
-- 🔧 chore(deps): update runtime dependencies
-- 🐛 fix: refine editor and problem navigation UI
-- 🐛 fix: restore scheduled contest reminders
-- ✨ feat: include authenticated AtCoder contests
-- 🐛 fix: improve editor home and reminder behavior
-- 📝 docs: AGENTS.mdにファイル編集や新規作成の許可を追加
-- ✅ test: add widget tests for various screens and components to support enlarged text on narrow screens - Implemented tests for settings screen, template edit screen, TeX test screen, and upcoming contests screen. - Added tests for responsive behavior of bottom navigation, browser site form fields, and recommendation problem card. - Ensured that dialogs and notifications handle enlarged text correctly. - Verified that various UI components maintain usability and aesthetics across different screen sizes.
-- ♻️  refactor: shared state cards and tighten UI radii
-- ✨ feat: UIの改善と機能追加
-- ✨ feat: adjust gutter width in code editor for improved layout
-- ✨ feat: adjust code editor gutter width and padding for improved layout
-- ✨ feat: implement translucent app bar and improve focus handling in editor - Added TranslucentAppBar for better UI experience. - Enhanced focus management in the editor screen for improved usability. - Updated browser screen layout for better responsiveness.
-- ✨ feat: add responsive layout utilities and loading indicator widget
-- Update UI
-- ✨ feat: add animated tab stack for smoother navigation transitions
-- 🐛 fix: handle context mounted state in various screens and services - Added checks for context mounted state in editor, recommend, settings, and update services to prevent errors. - Refactored recommendation controls in the recommend screen for better layout handling. - Updated tests to ensure proper functionality of new features and fixes.
-- 🐛 fix: move problem source link to footer
-- 🐛 fix: unify supported editor languages
-- 🔧 chore: remove robots.txt file
-- 🐛 fix: default code font to HackGen35
-- 🐛 fix: use proper programming language logos
-- 📝 docs: track remaining product improvements
-- ✨ feat: customize home widgets
-- ✨ feat: show recommended problem titles
-- 🐛 fix: schedule contest reminders
-- ✨ feat: improve editor and settings usability
-- a
-- auto fix
-- 🔧 chore: Gradle設定と通知サービスの初期化を更新 - Gradleのバージョンを8.14.3に更新 - Kotlinプラグインのバージョンを2.2.20に更新 - NotificationServiceの初期化設定を整理し、引数名を明確化
-- 📝 docs: 開発環境のセットアップ手順を追加
-- 🔧 chore: .fvmrcを削除し、Flutter SDKのバージョンを更新 - .fvmrcファイルを削除しました。 - pubspec.lockでDartとFlutterのバージョンを更新しました。 - mise.tomlを新規作成し、Flutterのバージョンを設定しました。
-- ✨ feat(atcoder): AtCoderコンテンツの取り扱いに関する法律情報を追加 feat(atcoder): AtCoderの元ページを開くボタンを問題詳細画面に追加 feat(atcoder): リクエストの間隔を制限するレートリミッターを実装 feat(atcoder): AtCoderプロフィールを解析するパーサーを追加 test: AtCoderプロフィールパーサーのユニットテストを追加 test: リクエストレートリミッターのユニットテストを追加
-- 📝 docs: READMEにバッジを追加して情報を強化
-- update readme
-- 📝 docs: README、開発ガイド、インストールガイド、法的情報、リリースプロセスの追加
-- ♻️  refactor(home_screen): reorder imports and remove reminder settings button
-- 🔧 chore(licenses): update OSS license snapshot
-- 🔧 chore(deps): bump google_fonts from 6.3.3 to 8.1.0
-- 🔧 chore(licenses): update OSS license snapshot
-- 🔧 chore(deps): bump fastlane from 2.228.0 to 2.236.1
-- 🔧 chore(deps): bump the pub-minor-patch group across 1 directory with 12 updates
-- README.md の更新
-- 🔧 chore(dependabot): group pub updates and add bundler support
-- Initial plan
-- 🐛 fix: GitHub Actionsの403 Forbidden エラーを修正するため、リポジトリの参照順序を変更
-- ci: ワークフローのトリガーを修正し、pushイベントの対象ブランチを明示化
+v1.3.0以来のエディターとUIを中心に、アプリ全体を再設計したメジャーアップデートです。
+
+### エディターとコード実行
+
+- コード編集領域を中心に「実行」「入出力」「提出」を下部のコマンドバーに集約した、新しいコードワークスペースへ刷新。
+- 標準入力と実行結果をタブで切り替える入出力シートを追加。サンプルテスト、`stdout` / `stderr`、終了コードの確認と結果のコピーを一か所で行えます。
+- 言語選択と、保存・履歴・復元・リセット・共有をAppBarに整理。コード履歴は日時表示、コピー、エディターへの復元に対応しました。
+- 標準エディターとMonaco Editorの切り替えは維持しつつ、Monacoを2.1.1へ更新。ガター幅、複数桁の行番号、フォーカス、キーボード開閉時のレイアウトを改善しました。
+
+### ホームとおすすめ問題
+
+- 「次回のABC」「おすすめ問題」「AtCoder Clans」の並べ替え・表示/非表示・初期化に対応。保存後は変更をすぐ元に戻せます。
+- 保存済みのAtCoderユーザー名からおすすめ問題を自動取得し、問題名・難易度・レート差をホームに表示。条件の下限差/上限差とユーザー名の再編集も行えます。
+- ウィジェットを全て非表示にした場合や、未設定・通信エラー・該当問題なしの状態から復帰できる導線を追加しました。
+
+### AtCoder連携と問題表示
+
+- AtCoderプロフィールからレーティングとRated Matchesを取得する専用パーサーを追加し、おすすめ問題とAtCoderカラーテーマの取得を安定化。AtCoderへのリクエストは1秒間隔で直列化しました。
+- 問題詳細にAtCoderの元ページを開く導線を追加。問題文の強調、箇条書き、`details` / `summary`、コードブロック、入力形式の説明とTeXの境界を保って表示するよう解析を改善しました。
+- インライン数式と独立数式の描画を分け、長い数式を横スクロールに対応。Markdownの太字・斜体・インラインコード・リスト記号も保持します。
+- AtCoderブラウザのログインセッションでのみ見える今後のコンテストを取り込み、公開コンテスト一覧と統合。セッションCookie自体は保存しません。
+
+### コンテスト通知
+
+- ABC・ARC・AGC・AHC・その他を個別に有効化し、複数の通知時刻を追加/削除できる設定画面に改善しました。
+- 通知権限は初回起動時ではなく、リマインダーを有効にした時だけ要求します。
+- 保存した設定と最新の開催予定を起動時に同期。無効化した通知の取り消し、アプリ更新・端末再起動後の予約復元、通信失敗時に既存予約を保持する処理を追加しました。
+
+### ブラウザーと提出の安全性
+
+- デフォルトサイトとカスタムサイトの切り替え、追加・編集・削除画面をレスポンシブ化。埋め込みWebView非対応環境では外部ブラウザーへ退避できます。
+- カスタムサイトはHTTP/HTTPSのみを受け付け、`javascript:`・`file:`・認証情報付きURLを拒否。インポートされた外部favicon URLも破棄し、明示操作以外の意図しない通信を防ぎます。
+- 提出画面の遷移先を正規のAtCoder HTTPSオリジンに限定し、コード自動入力は実際のコンテスト提出ページでのみ実行するよう強化しました。
+
+### UI・アクセシビリティ・設定
+
+- 主要画面をMaterial 3 Expressiveベースで再設計。AppBarとボトムナビゲーションを半透明・エッジトゥエッジ化し、共通の透明度設定とタブ切り替えアニメーションを追加しました。
+- 狭いスマートフォン、横長画面、拡大文字、キーボード表示時に対応する共通レスポンシブレイアウトを導入。ローディング・空・エラー状態にも読み上げ用ラベルと再試行導線を追加しました。
+- AtCoderのレート色をprimaryだけでなくsecondary / tertiary系にも反映し、Material Youのサーフェス階調と両立。Androidのステータスバー/ナビゲーションバーもテーマに合わせました。
+- 設定画面をAtCoder、テーマ、エディター、テンプレート、更新、バックアップ、アプリ情報に整理。設定のクリップボード/ファイル復元で文字列リストも正しく戻し、日本語の結果表示と再起動案内を追加しました。
+- ライセンス表示を「直接依存」「全依存」「Flutter標準」の3種類に分離。自己更新画面とダウンロード/インストール案内もテーマと拡大文字に対応しました。F-Droid版では自己更新を無効にしたまま、入手先を明示します。
+
+### 主な修正と安定性向上
+
+- 保存設定や通知プラグインの初期化完了を待たずに初回フレームを表示し、起動停止を回避。Web / Windows / Linuxなど非対応環境ではWebViewと通知初期化を安全にスキップします。
+- 非選択タブからフォーカスを外し、画面から戻った時に過去の入力欄がソフトウェアキーボードを再表示する問題を修正。
+- 非同期処理後の画面破棄を考慮し、エディター、おすすめ問題、設定、更新処理のクラッシュを防止。入力値、問題遷移、コンテキスト保持も安定化しました。
+
+### 互換性に関する重要な変更
+
+- 対応言語を **Python、C++、Rust、Java** の4言語に統一し、C#サポートを終了しました。
+- 従来の `HackGen` フォントを削除し、既定値を `HackGen35` へ変更。`HackGen` を使用していた保存設定は `HackGen35` へ自動移行します。
+- アプリ名の表示を「Shojin App」から「精進アプリ」へ統一しました。
+
+### 開発・ビルド基盤
+
+- Flutter 3.44.6、Gradle 8.14.3、Android Gradle Plugin 8.11.1、Kotlin 2.2.20へ更新し、主要なFlutter / Ruby依存も更新しました。
+- Material You対応を安定させるため `dynamic_color` をリポジトリ内で固定し、OSS / F-Droid両フレーバーのビルドとライセンス情報を更新しました。
+- 開発、インストール、法的情報、リリース運用の文書を整備。テストファイルを39個追加し、レスポンシブ表示、通知、ブラウザー安全性、問題文解析、バックアップ復元などを検証しました。
 
 
 ## [1.3.0] - Akeome Release (2026-01-06)


### PR DESCRIPTION
## 変更内容

- v1.3.0からv2.0.0までの82コミット・178ファイルの差分を実装単位で確認
- 自動生成されたコミットタイトル列挙を、利用者向けの構造化したリリースノートに置き換え
- C#サポート終了、HackGen35への移行、通知権限の要求タイミングなどの互換性変更を明記

## 目的

公開済みv2.0.0の変更内容を、エディター、AtCoder連携、通知、セキュリティ、UI、互換性、ビルド基盤の観点から正確に伝えるためです。

## 影響

CHANGELOGのv2.0.0セクションのみを更新します。アプリの実行コードに変更はありません。

## 検証

- `git diff --check`
- 記載したバージョン、対応言語、フォント移行、通知・ブラウザーポリシーを実装とテストに照合
