### PR TITLE
fix: support dated release note headings

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -65,9 +65,10 @@ jobs:
         id: notes
         run: |
           VER='${{ steps.version.outputs.value }}'
-          # Match the complete heading literally, then stop at the next version.
+          # Match the bracketed version literally while allowing a date or
+          # release name after it, then stop at the next version heading.
           awk -v heading="## [$VER]" '
-            $0 == heading { capture=1; next }
+            index($0, heading) == 1 { capture=1; next }
             capture && /^## \[/ { exit }
             capture { print }
           ' CHANGELOG.md > /tmp/section.txt


### PR DESCRIPTION
## 変更内容

日付やリリース名が続くCHANGELOG見出し（例: `## [2.0.0] - 2026-07-16`）から、対象バージョンの本文を正しく抽出します。

## 原因

前回の修正は見出し全体の完全一致を要求していたため、日付付き見出しに一致せずプレースホルダーへフォールバックしていました。

## 検証

- Linux `awk` で2.0.0節を61行抽出
- 次の1.3.0節を含まないことを確認
- YAML構文解析
- `git diff --check`