### PR TITLE
ci: validate release workflow changes

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -7,6 +7,9 @@ on:
     paths:
       - "pubspec.yaml"
       - "CHANGELOG.md"
+      # Run release-pipeline fixes through the same end-to-end path they change.
+      - ".github/workflows/publish-release.yml"
+      - ".github/workflows/release.yaml"
 
 permissions:
   contents: write


### PR DESCRIPTION
## 変更内容

リリースワークフロー自身への変更でも `Publish Release` を起動し、タグ解決・リリースノート抽出・APK資産スキップをエンドツーエンドで検証します。

## 検証

- YAML構文解析
- `git diff --check`