### PR TITLE
fix: unify display name as Shojin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- アプリの表示名を全プラットフォームで「Shojin」に統一
+
 ## [2.0.0] - 2026-07-16
 
 - ci: remove Gemini and license snapshot workflows

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">精進アプリ</string>
+    <string name="app_name">Shojin</string>
 </resources>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>Shojin App</string>
+	<string>Shojin</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -1,4 +1,4 @@
 {
   "@@locale": "en",
-  "appTitle": "Shojin App"
+  "appTitle": "Shojin"
 }

--- a/lib/l10n/app_ja.arb
+++ b/lib/l10n/app_ja.arb
@@ -1,4 +1,4 @@
 {
   "@@locale": "ja",
-  "appTitle": "精進アプリ"
+  "appTitle": "Shojin"
 }

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -101,7 +101,7 @@ abstract class AppLocalizations {
   /// No description provided for @appTitle.
   ///
   /// In en, this message translates to:
-  /// **'Shojin App'**
+  /// **'Shojin'**
   String get appTitle;
 }
 

--- a/lib/l10n/app_localizations_en.dart
+++ b/lib/l10n/app_localizations_en.dart
@@ -9,5 +9,5 @@ class AppLocalizationsEn extends AppLocalizations {
   AppLocalizationsEn([String locale = 'en']) : super(locale);
 
   @override
-  String get appTitle => 'Shojin App';
+  String get appTitle => 'Shojin';
 }

--- a/lib/l10n/app_localizations_ja.dart
+++ b/lib/l10n/app_localizations_ja.dart
@@ -9,5 +9,5 @@ class AppLocalizationsJa extends AppLocalizations {
   AppLocalizationsJa([String locale = 'ja']) : super(locale);
 
   @override
-  String get appTitle => '精進アプリ';
+  String get appTitle => 'Shojin';
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -300,7 +300,7 @@ class MyApp extends StatelessWidget {
         );
 
         return MaterialApp(
-          title: '精進アプリ',
+          title: 'Shojin',
           localizationsDelegates: const [
             AppLocalizations.delegate,
             GlobalMaterialLocalizations.delegate,

--- a/lib/services/settings_service.dart
+++ b/lib/services/settings_service.dart
@@ -30,7 +30,7 @@ class SettingsService {
       await file.writeAsString(jsonString);
 
       await SharePlus.instance.share(
-        ShareParams(files: [XFile(file.path)], text: '精進アプリの設定'),
+        ShareParams(files: [XFile(file.path)], text: 'Shojinの設定'),
       );
       _showSnackBar('設定ファイルを共有しました');
     } catch (_) {

--- a/linux/runner/my_application.cc
+++ b/linux/runner/my_application.cc
@@ -40,11 +40,11 @@ static void my_application_activate(GApplication* application) {
   if (use_header_bar) {
     GtkHeaderBar* header_bar = GTK_HEADER_BAR(gtk_header_bar_new());
     gtk_widget_show(GTK_WIDGET(header_bar));
-    gtk_header_bar_set_title(header_bar, "shojin_app");
+    gtk_header_bar_set_title(header_bar, "Shojin");
     gtk_header_bar_set_show_close_button(header_bar, TRUE);
     gtk_window_set_titlebar(window, GTK_WIDGET(header_bar));
   } else {
-    gtk_window_set_title(window, "shojin_app");
+    gtk_window_set_title(window, "Shojin");
   }
 
   gtk_window_set_default_size(window, 1280, 720);

--- a/macos/Runner/Base.lproj/MainMenu.xib
+++ b/macos/Runner/Base.lproj/MainMenu.xib
@@ -22,11 +22,11 @@
         <customObject id="YLy-65-1bz" customClass="NSFontManager"/>
         <menu title="Main Menu" systemMenu="main" id="AYu-sK-qS6">
             <items>
-                <menuItem title="APP_NAME" id="1Xt-HY-uBw">
+                <menuItem title="Shojin" id="1Xt-HY-uBw">
                     <modifierMask key="keyEquivalentModifierMask"/>
-                    <menu key="submenu" title="APP_NAME" systemMenu="apple" id="uQy-DD-JDr">
+                    <menu key="submenu" title="Shojin" systemMenu="apple" id="uQy-DD-JDr">
                         <items>
-                            <menuItem title="About APP_NAME" id="5kV-Vb-QxS">
+                            <menuItem title="About Shojin" id="5kV-Vb-QxS">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <connections>
                                     <action selector="orderFrontStandardAboutPanel:" target="-1" id="Exp-CZ-Vem"/>
@@ -40,7 +40,7 @@
                                 <menu key="submenu" title="Services" systemMenu="services" id="hz9-B4-Xy5"/>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="4je-JR-u6R"/>
-                            <menuItem title="Hide APP_NAME" keyEquivalent="h" id="Olw-nP-bQN">
+                            <menuItem title="Hide Shojin" keyEquivalent="h" id="Olw-nP-bQN">
                                 <connections>
                                     <action selector="hide:" target="-1" id="PnN-Uc-m68"/>
                                 </connections>
@@ -58,7 +58,7 @@
                                 </connections>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="kCx-OE-vgT"/>
-                            <menuItem title="Quit APP_NAME" keyEquivalent="q" id="4sb-4s-VLi">
+                            <menuItem title="Quit Shojin" keyEquivalent="q" id="4sb-4s-VLi">
                                 <connections>
                                     <action selector="terminate:" target="-1" id="Te7-pn-YzF"/>
                                 </connections>
@@ -330,7 +330,7 @@
             </items>
             <point key="canvasLocation" x="142" y="-258"/>
         </menu>
-        <window title="APP_NAME" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" animationBehavior="default" id="QvC-M9-y7g" customClass="MainFlutterWindow" customModule="Runner" customModuleProvider="target">
+        <window title="Shojin" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" animationBehavior="default" id="QvC-M9-y7g" customClass="MainFlutterWindow" customModule="Runner" customModuleProvider="target">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <rect key="contentRect" x="335" y="390" width="800" height="600"/>
             <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1577"/>

--- a/macos/Runner/Info.plist
+++ b/macos/Runner/Info.plist
@@ -10,6 +10,8 @@
 	<string></string>
 	<key>CFBundleIdentifier</key>
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleDisplayName</key>
+	<string>Shojin</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/test/screens/settings_screen_test.dart
+++ b/test/screens/settings_screen_test.dart
@@ -197,7 +197,7 @@ void main() {
           home: Scaffold(
             body: SettingsScreen(
               aboutInfoLoader: () async => {
-                'appName': '精進アプリ',
+                'appName': 'Shojin',
                 'packageName': 'io.github.shojinapp.kyopro',
                 'buildNumber': '100',
                 'platform': 'Android',

--- a/web/index.html
+++ b/web/index.html
@@ -23,13 +23,13 @@
   <!-- iOS meta tags & icons -->
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
-  <meta name="apple-mobile-web-app-title" content="shojin_app">
+  <meta name="apple-mobile-web-app-title" content="Shojin">
   <link rel="apple-touch-icon" href="icons/Icon-192.png">
 
   <!-- Favicon -->
   <link rel="icon" type="image/png" href="favicon.png"/>
 
-  <title>shojin_app</title>
+  <title>Shojin</title>
   <link rel="manifest" href="manifest.json">
 </head>
 <body>

--- a/web/manifest.json
+++ b/web/manifest.json
@@ -1,6 +1,6 @@
 {
-    "name": "shojin_app",
-    "short_name": "shojin_app",
+    "name": "Shojin",
+    "short_name": "Shojin",
     "start_url": ".",
     "display": "standalone",
     "background_color": "#0175C2",

--- a/windows/runner/Runner.rc
+++ b/windows/runner/Runner.rc
@@ -90,12 +90,12 @@ BEGIN
         BLOCK "040904e4"
         BEGIN
             VALUE "CompanyName", "com.example" "\0"
-            VALUE "FileDescription", "shojin_app" "\0"
+            VALUE "FileDescription", "Shojin" "\0"
             VALUE "FileVersion", VERSION_AS_STRING "\0"
             VALUE "InternalName", "shojin_app" "\0"
             VALUE "LegalCopyright", "Copyright (C) 2025 com.example. All rights reserved." "\0"
             VALUE "OriginalFilename", "shojin_app.exe" "\0"
-            VALUE "ProductName", "shojin_app" "\0"
+            VALUE "ProductName", "Shojin" "\0"
             VALUE "ProductVersion", VERSION_AS_STRING "\0"
         END
     END

--- a/windows/runner/main.cpp
+++ b/windows/runner/main.cpp
@@ -27,7 +27,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
   FlutterWindow window(project);
   Win32Window::Point origin(10, 10);
   Win32Window::Size size(1280, 720);
-  if (!window.Create(L"shojin_app", origin, size)) {
+  if (!window.Create(L"Shojin", origin, size)) {
     return EXIT_FAILURE;
   }
   window.SetQuitOnClose(true);


### PR DESCRIPTION
## 変更内容

- Android、iOS、macOS、Windows、Linux、Webのユーザー向け表示名を `Shojin` に統一
- Flutterの日本語・英語ローカライズと共有文言を `Shojin` に更新
- パッケージ名、Bundle ID、アプリケーションID、実行ファイル名は変更せず互換性を維持
- Unreleased CHANGELOGへ名称変更を記録

## 背景

v2.0.0では表示名が `精進アプリ`、`Shojin App`、`shojin_app` に分かれていたため、短いブランド名 `Shojin` に統一します。

## 検証

- `flutter gen-l10n`
- `dart format`
- `flutter analyze --no-pub`（問題なし）
- `flutter test --no-pub`（102件成功）
- `git diff --check`